### PR TITLE
Fix framerate doubling on hi3516 cams

### DIFF
--- a/src/common/media-element.cpp
+++ b/src/common/media-element.cpp
@@ -21,17 +21,6 @@
 
 #include "media-element.h"
 
-#if 0
-#ifdef HAVE_HI3516CV300_SUPPORT
-#define USING_HIMPP_BADVIDEO 1
-#include "platform/hi3516cv300/himpp-base.h"
-#endif
-#ifdef HAVE_HI3518V200_SUPPORT
-#define USING_HIMPP_BADVIDEO 1
-#include "platform/hi3618v200/himpp-base.h"
-#endif
-#endif
-
 namespace Ipcam {
 namespace Media {
 
@@ -119,19 +108,8 @@ uint32_t VideoElement::framerate()
 	if (upstream == NULL)
 		throw IpcamError("Not implemented");
 
-#ifdef USING_HIMPP_BADVIDEO
-	// nasty hack to see if we're using a himpp element that erroneously
-	// 'doubles' the codec framerate
-	try {
-		himpp_element = HIMPP_VIDEO_ELEMENT(upstream);
-		return upstream->framerate() / 2;
-	}
-	catch (std::bad_cast &c) {
-		return upstream->framerate();
-	}
-#else
 	return upstream->framerate();
-#endif
+
 }
 
 

--- a/src/common/media-element.cpp
+++ b/src/common/media-element.cpp
@@ -21,6 +21,17 @@
 
 #include "media-element.h"
 
+#if 0
+#ifdef HAVE_HI3516CV300_SUPPORT
+#define USING_HIMPP_BADVIDEO 1
+#include "platform/hi3516cv300/himpp-base.h"
+#endif
+#ifdef HAVE_HI3518V200_SUPPORT
+#define USING_HIMPP_BADVIDEO 1
+#include "platform/hi3618v200/himpp-base.h"
+#endif
+#endif
+
 namespace Ipcam {
 namespace Media {
 
@@ -108,7 +119,19 @@ uint32_t VideoElement::framerate()
 	if (upstream == NULL)
 		throw IpcamError("Not implemented");
 
+#ifdef USING_HIMPP_BADVIDEO
+	// nasty hack to see if we're using a himpp element that erroneously
+	// 'doubles' the codec framerate
+	try {
+		himpp_element = HIMPP_VIDEO_ELEMENT(upstream);
+		return upstream->framerate() / 2;
+	}
+	catch (std::bad_cast &c) {
+		return upstream->framerate();
+	}
+#else
 	return upstream->framerate();
+#endif
 }
 
 

--- a/src/common/media-element.cpp
+++ b/src/common/media-element.cpp
@@ -109,7 +109,6 @@ uint32_t VideoElement::framerate()
 		throw IpcamError("Not implemented");
 
 	return upstream->framerate();
-
 }
 
 

--- a/src/platform/hi3516cv300/himpp-video-venc.cpp
+++ b/src/platform/hi3516cv300/himpp-video-venc.cpp
@@ -40,7 +40,8 @@ HimppVencChan::HimppVencChan
     _resolution(source->resolution()),
     _framerate(source->framerate()),
     _bitrate(2048),
-    _gop(_framerate * 2),
+    //_gop(_framerate * 2),
+    _gop(_framerate),
     _min_qp(16),
     _max_qp(51),
 	_refmode(1, 0, true),
@@ -791,7 +792,8 @@ void HimppVencChan::doEnableElement()
 		if ((s32Ret = HI_MPI_VENC_GetH264Vui(_chnid, &stVui)) == HI_SUCCESS) {
 			stVui.stVuiTimeInfo.timing_info_present_flag = 1;
 			stVui.stVuiTimeInfo.num_units_in_tick = 1;
-			stVui.stVuiTimeInfo.time_scale = _framerate * 2;
+			//stVui.stVuiTimeInfo.time_scale = _framerate * 2;
+			stVui.stVuiTimeInfo.time_scale = _framerate;
 			if ((s32Ret = HI_MPI_VENC_SetH264Vui(_chnid, &stVui)) != HI_SUCCESS) {
 				HIMPP_PRINT("HI_MPI_VENC_SetH264Vui(%d) failed [%#x]\n",
 							_chnid, s32Ret);
@@ -859,7 +861,8 @@ void HimppVencChan::doEnableElement()
 		if ((s32Ret = HI_MPI_VENC_GetH265Vui(_chnid, &stVui)) == HI_SUCCESS) {
 			stVui.stVuiTimeInfo.timing_info_present_flag = 1;
 			stVui.stVuiTimeInfo.num_units_in_tick = 1;
-			stVui.stVuiTimeInfo.time_scale = _framerate * 2;
+			//stVui.stVuiTimeInfo.time_scale = _framerate * 2;
+			stVui.stVuiTimeInfo.time_scale = _framerate;
 			if ((s32Ret = HI_MPI_VENC_SetH265Vui(_chnid, &stVui)) != HI_SUCCESS) {
 				HIMPP_PRINT("HI_MPI_VENC_SetH265Vui(%d) failed [%#x]\n",
 							_chnid, s32Ret);


### PR DESCRIPTION
The apparent use of the hardware media api on the hi3516 cameras tells
the hardware to use double the GOP and framerates for h264/265 video. On
h265 at least this results in bad metadata. Needs more testing on h264.

Tested on h264 too, with AV sync tests as well.